### PR TITLE
Remove missing docs links and minimize release branch prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ following new functionality:
   [CockroachDB](https://github.com/cockroachdb/cockroach), etc.)
 * Controllers to provision these resources in a Rook Kubernetes cluster based on
   the users desired state captured in CRDs they create
-* Implementations of Crossplane's [portable resource
-  abstractions](https://crossplane.io/docs/master/concepts.html), enabling Rook
+* Implementations of Crossplane's portable resource abstractions, enabling Rook
   resources to fulfill a user's general need for cloud services
 
 ## Getting Started and Documentation

--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -14,7 +14,7 @@ readme: |
 
  * Custom Resource Definitions (CRDs) that model Rook infrastructure and services (e.g. [Yugabyte](https://github.com/yugabyte/yugabyte-db), [CockroachDB](https://github.com/cockroachdb/cockroach), etc.)
  * Controllers to provision these resources in a Rook Kubernetes cluster based on the users desired state captured in CRDs they create
- * Implementations of Crossplane's [portable resource abstractions](https://crossplane.io/docs/master/concepts.html), enabling Rook resources to fulfill a user's general need for cloud services
+ * Implementations of Crossplane's portable resource abstractions, enabling Rook resources to fulfill a user's general need for cloud services
 
 # Maintainer names and emails.
 maintainers:

--- a/config/stack/manifests/resources/cockroachclusterclass.resource.yaml
+++ b/config/stack/manifests/resources/cockroachclusterclass.resource.yaml
@@ -6,5 +6,5 @@ overviewShort: "A CockroachClusterClass is a resource class. It defines the desi
 overview: |
   A CockroachClusterClass is a resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource.
 readme: |
-  Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-rook/storage-rook-crossplane-io-v1alpha1.html#CockroachClusterClass).
+  Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-rook/database.rook.crossplane.io_cockroachclusterclasses.yaml).
 

--- a/config/stack/manifests/resources/yugabyteclusterclass.resource.yaml
+++ b/config/stack/manifests/resources/yugabyteclusterclass.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A YugabyteClusterClass is a resource class. It defines the desir
 overview: |
   A YugabyteClusterClass is a resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource.
 readme: |
-  Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-rook/storage-rook-crossplane-io-v1alpha1.html#YugabyteClusterClass).
+  Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-rook/database.rook.crossplane.io_yugabyteclusterclasses.yaml).


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

The `portable resource abstractions` link no longer exists (this change was already made in release). The docs api references no longer exist on `master` and the `v0.5` release was the last one in which they did. These changes also remove almost all updates required in our branch prep PRs.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/stack-gcp/blob/master/config/stack/manifests/app.yaml