### PR TITLE
Run provider-rook controllers as non-root

### DIFF
--- a/cluster/images/provider-rook/Dockerfile
+++ b/cluster/images/provider-rook/Dockerfile
@@ -9,4 +9,5 @@ ADD stack /usr/local/bin/crossplane-rook-stack
 COPY stack-package /
 
 EXPOSE 8080
+USER 1001
 ENTRYPOINT ["crossplane-rook-stack"]


### PR DESCRIPTION

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->



### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->


This updates the provider-gcp Dockerfile to run as non-root
as the Crossplane stack manager will refuse to run containers
as root by default per crossplane/crossplane#1444

See https://github.com/crossplane/provider-gcp/pull/223 for testing

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/stack-gcp/blob/master/config/stack/manifests/app.yaml