### PR TITLE
Revert "[release-0.7] Prep versions for v0.7.0 release"

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -166,8 +166,8 @@ HOSTARCH="${HOSTARCH:-amd64}"
 BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${HOSTARCH}"
 
 version_tag="$(cat ${projectdir}/_output/version)"
-# tag as v0.7.0 so that config/package/install.yaml can be used
-PACKAGE_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:v0.7.0"
+# tag as master so that config/package/install.yaml can be used
+PACKAGE_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:master"
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-INTTESTS}"
 
 CROSSPLANE_NAMESPACE="crossplane-system"

--- a/config/package/manifests/resources/cockroachclusterclass.resource.yaml
+++ b/config/package/manifests/resources/cockroachclusterclass.resource.yaml
@@ -6,5 +6,5 @@ overviewShort: "A CockroachClusterClass is a resource class. It defines the desi
 overview: |
   A CockroachClusterClass is a resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource.
 readme: |
-  Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-rook/config/crd/database.rook.crossplane.io_cockroachclusterclasses.yaml@v0.7.0).
+  Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-rook/database.rook.crossplane.io_cockroachclusterclasses.yaml).
 

--- a/config/package/manifests/resources/yugabyteclusterclass.resource.yaml
+++ b/config/package/manifests/resources/yugabyteclusterclass.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A YugabyteClusterClass is a resource class. It defines the desir
 overview: |
   A YugabyteClusterClass is a resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource.
 readme: |
-  Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-rook/config/crd/database.rook.crossplane.io_yugabyteclusterclasses.yaml@v0.7.0).
+  Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-rook/database.rook.crossplane.io_yugabyteclusterclasses.yaml).

--- a/config/package/samples/install.package.yaml
+++ b/config/package/samples/install.package.yaml
@@ -5,4 +5,4 @@ metadata:
   name: provider-rook
   namespace: rook
 spec:
-  package: "crossplane/provider-rook:v0.7.0"
+  package: "crossplane/provider-rook:master"


### PR DESCRIPTION
Reverts crossplane/provider-rook#63 because it went to wrong branch.