### PR TITLE
Enable leader election for controller manager

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -32,9 +32,10 @@ import (
 
 func main() {
 	var (
-		app        = kingpin.New(filepath.Base(os.Args[0]), "Rook support for Crossplane.").DefaultEnvars()
-		debug      = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
-		syncPeriod = app.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").Duration()
+		app            = kingpin.New(filepath.Base(os.Args[0]), "Rook support for Crossplane.").DefaultEnvars()
+		debug          = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
+		syncPeriod     = app.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").Duration()
+		leaderElection = app.Flag("leader-election", "Use leader election for the conroller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -52,7 +53,11 @@ func main() {
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{SyncPeriod: syncPeriod})
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		LeaderElection:   *leaderElection,
+		LeaderElectionID: "crossplane-leader-election-provider-rook",
+		SyncPeriod:       syncPeriod,
+	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add AWS APIs to scheme")


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR enables leader election for Rook provider controller manager. This can be controlled by `--leader-election` CLI flag or `LEADER_ELECTION=true` environment variables. This can be achieved for deployment by applying the following:

```yaml
apiVersion: pkg.crossplane.io/v1alpha1
kind: ControllerConfig
metadata:
  name: rook-config
spec:
  replicas: 2
  env:
    - name: "LEADER_ELECTION"
      value: "true"
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Partial fix for https://github.com/crossplane/crossplane/issues/5

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

TBA

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
